### PR TITLE
Fix legacy input format

### DIFF
--- a/cryptos/coins_async/base.py
+++ b/cryptos/coins_async/base.py
@@ -884,7 +884,7 @@ class BaseCoin:
                 txobj = self.sign(txobj, i, priv)
         return txobj
 
-    def multisign(self, txobj: Union[str, Tx], i: int, script: str, priv) -> Tx:
+    def multisign(self, txobj: Union[str, Tx], i: int, script: str, priv: PrivkeyType) -> Tx:
         i = int(i)
         if not isinstance(txobj, dict):
             txobj = deserialize(txobj)
@@ -913,9 +913,12 @@ class BaseCoin:
         txobj = {"locktime": locktime, "version": 1}
         for i, inp in enumerate(ins):
             if isinstance(inp, string_or_bytes_types):
-                real_inp: TxInput = {"tx_hash": inp[:64], "tx_pos": int(inp[65:]), 'amount': 0}
+                real_inp: TxInput = {"tx_hash": inp[:64], "tx_pos": int(inp[65:])}
                 ins[i] = real_inp
                 inp = real_inp
+            elif inp_out := inp.pop('output', None):
+                tx_info: TxInput = {"tx_hash": inp_out[:64], "tx_pos": int(inp_out[65:])}
+                inp.update(tx_info)
             if address := inp.get('address', ''):
                 if self.segwit_supported and self.is_native_segwit(address):
                     txobj.update({"marker": 0, "flag": 1, "witness": []})

--- a/cryptos/transaction.py
+++ b/cryptos/transaction.py
@@ -159,6 +159,13 @@ def deserialize(tx: AnyStr) -> Tx:
     return obj
 
 
+def test_unhexlify(x):
+    try:
+        return binascii.unhexlify(x)
+    except binascii.Error:
+        raise Exception('Unhexlify failed for', x)
+
+
 def serialize(txobj: Tx, include_witness: bool = True) -> AnyStr:
     txobj = deepcopy(txobj)
     for i in txobj['ins']:
@@ -168,7 +175,7 @@ def serialize(txobj: Tx, include_witness: bool = True) -> AnyStr:
         txobj = bytes_to_hex_string(txobj)
     o = []
     if json_is_base(txobj, 16):
-        json_changedbase = json_changebase(txobj, lambda x: binascii.unhexlify(x))
+        json_changedbase = json_changebase(txobj, test_unhexlify)
         hexlified = safe_hexlify(serialize(json_changedbase, include_witness=include_witness))
         return hexlified
     o.append(encode_4_bytes(txobj["version"]))

--- a/cryptos/types.py
+++ b/cryptos/types.py
@@ -1,14 +1,15 @@
-from typing import TypedDict, Dict, Any
+from typing import TypedDict, Dict, Any, AnyStr
 from typing import List, AnyStr, Union, Callable, Awaitable
 from typing_extensions import NotRequired
 from .electrumx_client.types import ElectrumXTx
 
 
 class TxInput(TypedDict):
-    tx_hash: str
-    tx_pos: int
-    script: bytes
-    sequence: int
+    tx_hash: NotRequired[str]
+    tx_pos: NotRequired[int]
+    output: NotRequired[str]
+    script: NotRequired[AnyStr]
+    sequence: NotRequired[int]
     value: NotRequired[int]
     address: NotRequired[str]
 

--- a/tests/test_coins_async/test_bitcoin.py
+++ b/tests/test_coins_async/test_bitcoin.py
@@ -180,6 +180,36 @@ class TestBitcoin(BaseAsyncCoinTestCase):
     async def test_gettxs(self):
         await self.assertTxsOK()
 
+    def test_mktx_legacy_input_format(self):
+        """
+        Test support for {'output': 'txhash:txpos'} input format
+        """
+        inp = {'output': 'e068b7a30a15229005ff38be47ad419aea8ea519ed9ce26e94778ce2b690d44a:1',
+               'value': 5000000,
+               'address': '1MhTCMUjM1TEQ7RSwoCMVZy7ARa9aAP82Z'}
+        outs = []
+        tx = self._coin.mktx([inp], outs)
+        self.assertDictEqual(tx['ins'][0],
+                             {'tx_hash': 'e068b7a30a15229005ff38be47ad419aea8ea519ed9ce26e94778ce2b690d44a',
+                              'tx_pos': 1,
+                              'value': 5000000,
+                              'address': '1MhTCMUjM1TEQ7RSwoCMVZy7ARa9aAP82Z',
+                              'script': '',
+                              'sequence': 4294967295})
+
+    def test_mktx_legacy_input_format_str(self):
+        """
+        Test support for 'txhash:txpos str input format
+        """
+        inp = 'e068b7a30a15229005ff38be47ad419aea8ea519ed9ce26e94778ce2b690d44a:1'
+        outs = []
+        tx = self._coin.mktx([inp], outs)
+        self.assertDictEqual(tx['ins'][0],
+                             {'tx_hash': 'e068b7a30a15229005ff38be47ad419aea8ea519ed9ce26e94778ce2b690d44a',
+                              'tx_pos': 1,
+                              'script': '',
+                              'sequence': 4294967295})
+
     async def test_transaction(self):
         with mock.patch('cryptos.electrumx_client.client.NotificationSession.send_request',
                         side_effect=self.mock_electrumx_send_request):


### PR DESCRIPTION
Support a legacy input format {'output': 'txhash': txpos}