### PR TITLE
Faster sha256 function

### DIFF
--- a/cryptos/main.py
+++ b/cryptos/main.py
@@ -370,7 +370,7 @@ def bin_sha256(string):
     return hashlib.sha256(binary_data).digest()
 
 def sha256(string):
-    return bytes_to_hex_string(bin_sha256(string))
+    return hashlib.sha256(string.encode()).hexdigest()
 
 
 def bin_ripemd160(string):


### PR DESCRIPTION
Calling `hashlib.sha256` directly with the `hexdigest()` output is an order of magnitude faster.

Before change:
```
>>> timeit.timeit("import cryptos; cryptos.sha256('foo')", number=1000)
0.01851644799999974
```

After change:
```
>>> timeit.timeit("import cryptos; cryptos.sha256('foo')", number=1000)
0.0015009069999996072
```