### PR TITLE
fixed `ecdsa_verify` assertion failure

### DIFF
--- a/cryptos/main.py
+++ b/cryptos/main.py
@@ -456,7 +456,7 @@ def get_version_byte(inp):
     leadingzbytes = len(re.match('^1*', inp).group(0))
     data = b'\x00' * leadingzbytes + changebase(inp, 58, 256)
     assert bin_dbl_sha256(data[:-4])[:4] == data[-4:]
-    return ord(data[0])
+    return ord(data[0:1])
 
 
 def hex_to_b58check(inp, magicbyte=0):
@@ -570,12 +570,12 @@ def ecdsa_verify_addr(msg, sig, addr, coin):
     assert coin.is_address(addr)
     Q = ecdsa_recover(msg, sig)
     magic = get_version_byte(addr)
-    return (addr == coin.pubtoaddr(Q, int(magic))) or (addr == coin.pubtoaddr(compress(Q), int(magic)))
+    return (addr == pubkey_to_address(Q, int(magic))) or (addr == pubkey_to_address(compress(Q), int(magic)))
 
 
 def ecdsa_verify(msg, sig, pub, coin):
-    if coin.is_address(pub):
-        return ecdsa_verify_addr(msg, sig, pub, coin)
+    if coin.is_address(msg):
+        return ecdsa_verify_addr(msg, sig, coin.pubtoaddr(pub), coin)
     return ecdsa_raw_verify(electrum_sig_hash(msg), decode_sig(sig), pub)
 
 


### PR DESCRIPTION
Summary:
- Happens when the message is not an address.
- It's supposed to check if the message is an address, not the public key.
- Also, fixed bugs in `get_version_byte` and `ecdsa_verify_addr`.

Reproducer:
```python
from cryptos import (sha256, Bitcoin, ecdsa_sign)

priv = sha256('some big long brainwallet password')
print("priv:", priv)

chain = Bitcoin()

# take 1
message = "Hello, world!"
signature = ecdsa_sign(message, priv, chain)
print("signature:", signature)

# take 2
signature = ecdsa_sign("", priv, chain)
print("signature:", signature)

# take 3
addr = chain.privtoaddr(priv)
signature = ecdsa_sign(addr, priv, chain)
print("signature:", signature)
```
